### PR TITLE
Prevent extra carriage return in output CSV

### DIFF
--- a/git_log_stats_parser.py
+++ b/git_log_stats_parser.py
@@ -78,7 +78,8 @@ class GitLogStatsParser:
 
         commits = sorted(commit_dict.values(), key=lambda x: x['date'], reverse=True)
         csv_keys = commits[0].keys()
-        with open(out_csv_file, 'w') as csv_file:
+        
+        with open(out_csv_file, 'w', newline="") as csv_file:
             dict_writer = csv.DictWriter(csv_file, fieldnames=csv_keys)
             dict_writer.writeheader()
             dict_writer.writerows(commits)


### PR DESCRIPTION
Prevent addition of extra carriage return in output CSV. (https://stackoverflow.com/questions/3191528/csv-in-python-adding-an-extra-carriage-return-on-windows)